### PR TITLE
Add transformer to fix rehydrated state

### DIFF
--- a/src/redux/reducer.ts
+++ b/src/redux/reducer.ts
@@ -6,7 +6,7 @@ import {
   Actions
 } from './actions'
 
-const blankState: Information = { f1099s: [], w2s: [], taxPayer: { dependents: [] } }
+export const blankState: Information = { f1099s: [], w2s: [], taxPayer: { dependents: [] } }
 
 function formReducer (state: Information | undefined, action: Actions): Information {
   const newState: Information = state ?? blankState

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,16 +1,35 @@
 import { createStore, applyMiddleware } from 'redux'
 import logger from 'redux-logger'
-import rootReducer from './reducer'
+import rootReducer, { blankState } from './reducer'
 
-import { persistStore, persistReducer } from 'redux-persist'
+import { persistStore, persistReducer, createTransform } from 'redux-persist'
 import storage from 'redux-persist/lib/storage' // defaults to localStorage for web
+import { Information } from './data'
+import { Actions } from './actions'
+
+const baseTransform = createTransform(
+  // transform state on its way to being serialized and persisted.
+  (inboundState: Information, key) => {
+    return inboundState
+  },
+  // transform state being rehydrated
+  // Just ensure the state has all requisite root members
+  (outboundState: Information, key: keyof Information): Information => {
+    return {
+      ...blankState,
+      ...outboundState
+    }
+  },
+  { whitelist: ['information'] }
+)
 
 const persistConfig = {
   key: 'root',
-  storage
+  storage,
+  transforms: [baseTransform]
 }
 
-const persistedReducer = persistReducer(persistConfig, rootReducer)
+const persistedReducer = persistReducer<{information: Information}, Actions>(persistConfig, rootReducer)
 
 export const store = createStore(persistedReducer, applyMiddleware(logger))
 


### PR DESCRIPTION
This performs a basic check to make sure that all fields expected at the root level of rehydrated storage are present.

We should be able to improve on this by requiring schema updates be versioned, and each change would come with its own migration function.